### PR TITLE
Util: actually use Process::Status

### DIFF
--- a/lib/Git/BranchManager/Util.pm
+++ b/lib/Git/BranchManager/Util.pm
@@ -7,6 +7,7 @@ use warnings;
 use Config::INI::Reader;
 use List::Util qw(max);
 use JSON::MaybeXS qw(decode_json);
+use Process::Status;
 
 our $VERBOSE = 0;
 our $REALLY  = 0;


### PR DESCRIPTION
Otherwise the Process::Status->assert_ok call in `guess_config` fails.